### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# amharic-keyboard
+A javascript that enables developers to integrate amharic (Ethiopian Language) typing into their website.
+
+Try it out at:
+http://lehagere.github.io/amharic-keyboard


### PR DESCRIPTION
Add information on how to try out the keyboard

GitHub pages can host the keyboard. This can be enabled following instructions here:
https://docs.github.com/en/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#choosing-a-publishing-source

Have done this for the fork at:
https://github.com/bkmgit/amharic-keyboard

Resulting website is:
https://bkmgit.github.io/amharic-keyboard/